### PR TITLE
add temporary fix for pybind11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ class CMakeBuild(build_ext):
             return 0
         os.mkdir(dir_pybind11)
         subprocess.check_call(['git', 'clone',
+                               '--single-branch', '--branch', 'v2.4',
                                'https://github.com/pybind/pybind11.git',
                                dir_pybind11])
         os.chdir(dir_pybind11)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-learn/giotto-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#161

#### What does this implement/fix? Explain your changes.

clones pybind11 `v2.4` and not `master`. This is a temporary fix for enabling build the wheels due to commit 07e22593 at pybind11.

#### Any other comments?

A better solution shall be foud.

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
