### PR TITLE
Reshape for callable filters

### DIFF
--- a/giotto/mapper/cover.py
+++ b/giotto/mapper/cover.py
@@ -416,6 +416,10 @@ class CubicalCover(BaseEstimator, TransformerMixin):
 
         """
         _validate_kind(self.kind)
+        # reshape filter function values derived from FunctionTransformer
+        if X.ndim == 1:
+            X = X[:, None]
+
         X = check_array(X)
 
         return self._fit(X)
@@ -452,6 +456,10 @@ class CubicalCover(BaseEstimator, TransformerMixin):
 
         """
         check_is_fitted(self)
+        # reshape filter function values derived from FunctionTransformer
+        if X.ndim == 1:
+            X = X[:, None]
+
         X = check_array(X)
         n_features_fit = self._n_features_fit
         n_features = X.shape[1]
@@ -489,6 +497,11 @@ class CubicalCover(BaseEstimator, TransformerMixin):
 
         """
         _validate_kind(self.kind)
+
+        # reshape filter function values derived from FunctionTransformer
+        if X.ndim == 1:
+            X = X[:, None]
+
         X = check_array(X)
 
         if self.kind == 'uniform':

--- a/giotto/mapper/utils/pipeline.py
+++ b/giotto/mapper/utils/pipeline.py
@@ -14,7 +14,7 @@ def func_from_callable_on_rows(func):
         return None
     func_params = signature(func).parameters
     if 'axis' in func_params:
-        return partial(func, axis=1)
+        return partial(func, axis=1, keepdims=True)
     return make_func_apply_along_axis_1(func)
 
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
* Ensures that 1D filter values arrays have the required shape `(n_samples, 1)` when a NumPy callable like `np.sum` is used.
* For other cases, we check that 1D arrays have the required shape.